### PR TITLE
fix: Create step_4/output directory if it doesn't exist on user's file system.

### DIFF
--- a/land_grab_2/stl_dataset/step_4/dataset_summary_stats.py
+++ b/land_grab_2/stl_dataset/step_4/dataset_summary_stats.py
@@ -281,6 +281,9 @@ def calculate_summary_statistics_helper(summary_statistics_data_directory, merge
     if not stats_dir.exists():
         stats_dir.mkdir(parents=True, exist_ok=True)
 
+    if not output_dir.exists():
+        output_dir.mkdir(parents=True, exist_ok=True)
+
     gis_acres_col = GIS_ACRES if GIS_ACRES in df.columns else 'gis_calculated_acres'
     df[GIS_ACRES] = df[gis_acres_col].astype(float)
 


### PR DESCRIPTION
This PR fixes a (very) small issue I encountered replicating the data workflow.

### The Problem

When Stage 4 attempts to write to `data/stl_dataset/step_4/output`, the `step_4` and `output` directories don't yet exist; thus, users receive an error like the following:

```sh
# Full stack trace

OSError: Cannot save file into a non-existent directory: '/Users/parkie-doo/Documents/repos/grist/land-grab-2/data/stl_dataset/step_4/output'
  File "/Users/parkie-doo/.pyenv/versions/3.10.4/lib/python3.10/site-packages/pandas/io/common.py", line 597, in check_parent_directory
    raise OSError(rf"Cannot save file into a non-existent directory: '{parent}'")

OSError: Cannot save file into a non-existent directory: '/Users/parkie-doo/Documents/repos/grist/land-grab-2/data/stl_dataset/step_4/output'
```

### The Solution

We just check if the directory exists and create it if not!