### PR TITLE
Fix #35. Ensure parcel_count attribute is persisted to CSV output.

### DIFF
--- a/land_grab_2/stl_dataset/step_1/dataset_merge.py
+++ b/land_grab_2/stl_dataset/step_1/dataset_merge.py
@@ -10,7 +10,7 @@ import pandas as pd
 from land_grab_2.stl_dataset.step_1.constants import ALL_STATES, ACTIVITY, FINAL_DATASET_COLUMNS, \
     GIS_ACRES, \
     ALBERS_EQUAL_AREA, ACRES_TO_SQUARE_METERS, ACRES, OBJECT_ID, TRUST_NAME, ATTRIBUTE_LABEL_TO_FILTER_BY, \
-    ATTRIBUTE_CODE_TO_ALIAS_MAP
+    ATTRIBUTE_CODE_TO_ALIAS_MAP, PARCEL_COUNT
 from land_grab_2.stl_dataset.step_1.state_trust_config import STATE_TRUST_CONFIGS
 from land_grab_2.utilities.overlap import combine_dfs, fix_geometries
 from land_grab_2.utilities.utils import state_specific_directory, combine_delim_list, _get_filename
@@ -37,7 +37,7 @@ def _merge_dataframes(df_list):
         return df_list[0]
 
     # return the final merged dataset
-    merged = df_list[0] if len(df_list) == 1 else combine_dfs(df_list)
+    merged = combine_dfs(df_list)
     merged = geopandas.GeoDataFrame(merged, geometry=merged.geometry, crs=merged.crs)
     return merged
 
@@ -75,7 +75,7 @@ def condense_activities(row):
 
 
 def dedup_single(gdf):
-    gdf['PARCEL_COUNT'] = gdf.groupby('geometry')['geometry'].transform('count')
+    gdf[PARCEL_COUNT] = gdf.groupby('geometry')['geometry'].transform('count')
     all_trusts = set(gdf[TRUST_NAME].tolist())
     deduped_groups = []
     for trust in all_trusts:


### PR DESCRIPTION
This PR fixes the small issue outlined in the first comment of #35. Importantly, it does not remove the `SKIP_DEDUP` flag for MN (though that should be trivial once this is merged).

### The Problem

[This line](https://github.com/Grist-Data-Desk/land-grab-2/blob/a4e28f4d316f1337a7226a5b3502b6024136dcb8/land_grab_2/stl_dataset/step_1/dataset_merge.py#L78) was attempting to write an attribute `"PARCEL_COUNT"` (note the all caps) to each `GeoDataFrame`. Tracing program execution from this line, the dataframe (after some transformation) is handed off to `_merge_dataframes`, which in turn calls `combine_dfs` for cases where we need to merge more than one dataframe.

Inside of `combine_dfs`, we do some set computation to build up the set of attributes shared by all dataframes while also ensuring columns present in the constant `list` `FINAL_DATAFRAME_COLUMNS` are also present. Later, on [this line](https://github.com/Grist-Data-Desk/land-grab-2/blob/a4e28f4d316f1337a7226a5b3502b6024136dcb8/land_grab_2/utilities/overlap.py#L253), we subsequently drop all columns _not_ in `FINAL_DATAFRAME_COLUMNS`. The attribute `"PARCEL_COUNT"` is not in that list; instead, the string literal `"parcel_count"` (note the lowercase) is. This literal is represented by the constant `PARCEL_COUNT`.

### The Solution

Pretty small—just change the string literal `"PARCEL_COUNT"` to the constant binding `PARCEL_COUNT`, which represents the string literal `"parcel_count"`.

Along the way, I did notice an opportunity to remove a tiny bit of dead code from `overlap.py`. We already return early in `combine_dfs` when we have a `df_list` of length 1, so there's no need for the conditional check on `df_list` length afterwards.

 