### PR TITLE
fix: Ensure we include the activity name in addition to the value for activity_name_appendage_col.

### DIFF
--- a/land_grab_2/stl_dataset/step_2/land_activity_search/activity_match.py
+++ b/land_grab_2/stl_dataset/step_2/land_activity_search/activity_match.py
@@ -278,7 +278,7 @@ def get_activity_name(state, activity, activity_row):
     if activity.use_name_as_activity and activity.activity_name_appendage_col:
         col_val = activity_row[activity.activity_name_appendage_col]
         if col_val.values[0]:
-            activity_name = col_val.values[0]
+            activity_name = f"{activity.name} - {col_val.values[0]}"
 
     if activity_name is None:
         possible_activity_cols = get_activity_column(activity, state)


### PR DESCRIPTION
Pretty much as stated in the title. With this fix, previous activity values like "OPERATING" (in Texas) or "Sold" (in Idaho) now read as "Oil and gas Wellbores - OPERATING" or "Timber - Sold". In general, the idea is that we treat the value in the `activity_name_appendage_col` truly as an "appendage" of the `activity_name`. I can only imagine this is what the original author intended with the naming of this field!