### PR TITLE
fix: One-off edit to perform "correct" (I hope) translations of activities.

### DIFF
--- a/land_grab_2/stl_dataset/step_2/land_activity_search/activity_match.py
+++ b/land_grab_2/stl_dataset/step_2/land_activity_search/activity_match.py
@@ -251,7 +251,7 @@ def get_activity_column(activity, state):
     ]
 
 
-def translate_state_activity_code(activity_name, state):
+def translate_state_activity_code(activity_name):
     if isinstance(activity_name, float):
         activity_name = int(activity_name)
     if isinstance(activity_name, int):
@@ -297,11 +297,9 @@ def get_activity_name(state, activity, activity_row):
 
     if pd.notna(activity_name):
         if state == "WI":
-            appendage_col_value = translate_state_activity_code(
-                appendage_col_value, state
-            )
+            appendage_col_value = translate_state_activity_code(appendage_col_value)
         else:
-            activity_name = translate_state_activity_code(activity_name, state)
+            activity_name = translate_state_activity_code(activity_name)
 
     activity_name = (
         f"{activity_name} - {appendage_col_value}"


### PR DESCRIPTION
A bit of a clunker of a PR, but I believe it gets the job done. The crux of debugging this issue lied in pursuing a deeper exploration of `translate_state_activity_code`. In the cases of AZ, MT, and WA, passing the value of `activity.name` as the `activity_name` argument is important; for those states, `activity.name` will correspond to one of the keys in `AZ_KEY`, `MT_KEY`, and `WA_KEY`, respectively (for certain Shapefiles). For WI, however, we need to pass the value of `appendage_col_value`, since translation of state codes occurs on this secondary column.

In short, I think a huge source of the issues in this area of the codebase is that WI performs the translation on the values in the appendage column, not the primary activity column. In fact, it's the only state satisfying both of the following criteria:

1. Has configs with `use_name_ as_activity=True` and non-`None` `activity_name_appendage_col`.
2. Has a lookup table for translating state codes.

WI's persistent problems also probably made it easier for us to think the problem was fixed once WI's values looked correct. With this change, we start to see positive signs of correction:

- Problematic TX parcels with activities like "Producing – Producing" now read "Oil and gas lease – Producing"
- Problematic WI parcels with activities like "DNR Easement - 1222.0" now read "DNR Easement - Open to passive use only"

I also verified the AZ and MT lookups are appearing as expected.