### PR TITLE
fix activities so that they don't show up on WA timber-rights-type pa…

### DIFF
--- a/land_grab_2/stl_dataset/step_2/land_activity_search/activity_match.py
+++ b/land_grab_2/stl_dataset/step_2/land_activity_search/activity_match.py
@@ -313,6 +313,9 @@ def is_subsurface_activity(activity_name):
         return MISC_KEY.get(activity_name, 'surface') == 'subsurface'
 
 def is_incompatible_activity(grist_row, activity, activity_name, state):
+    if grist_row[STATE] == 'WA' and grist_row[RIGHTS_TYPE] == 'timber':
+        return True
+
     if grist_row[STATE] == state:
         
         restricted_rights_types_for_subsurface = ['subsurface']


### PR DESCRIPTION
Made a small change in the activity_match.py file so that any parcels in WA that have a timber rights-type do record any activity showing up in the activity field. 