### PR TITLE
Handle cession column types correctly

### DIFF
--- a/data/stl_dataset/step_2_5/output/stl_dataset_extra_activities_plus_cessions.geojson
+++ b/data/stl_dataset/step_2_5/output/stl_dataset_extra_activities_plus_cessions.geojson
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:68dcf357cfb06fd3ccea86bc821656a0d008c7d84ce6b15acdeff74bed8b55d9
-size 94741560
+oid sha256:784fcbd649e695260b86240795d8ffe947ddce156b5a96285c3876b817e92bdc
+size 96698471

--- a/data/stl_dataset/step_2_5/output/stl_dataset_extra_activities_plus_cessions_wgs84.geojson
+++ b/data/stl_dataset/step_2_5/output/stl_dataset_extra_activities_plus_cessions_wgs84.geojson
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:976896a0bc62f2696bf2ca8fac8ffd589490296744b36457d7dd357fbe3beb6e
-size 81809350
+oid sha256:49ac019fe3aa66532f9d652a0f2644fd7655ecc87b6465cabab42201cdffa6ff
+size 93599067

--- a/land_grab_2/stl_dataset/step_4/dataset_summary_stats.py
+++ b/land_grab_2/stl_dataset/step_4/dataset_summary_stats.py
@@ -81,16 +81,17 @@ def tribe_summary_for_univ_summary(df, col_filter_func, out_column_name):
 def combine_cession_ids(v):
     raw_nums_results = []
     for c in v.tolist():
-        if c and not (isinstance(c, str) or np.isnan(c)):
+        if isinstance(c, str):
             if ',' in c:
                 new_val = c.split(',')
             else:
                 new_val = c.split(' ')
             raw_nums_results.append(new_val)
+        elif np.issubdtype(type(c), np.number) and not np.isnan(c):
+            raw_nums_results.append([str(c)])
+    
     raw_nums = set(itertools.chain.from_iterable(raw_nums_results))
-
-    raw_nums = [n for n in raw_nums if n]
-    clean_nums = ';'.join(raw_nums)
+    clean_nums = ';'.join(filter(None, raw_nums))    
     return clean_nums
 
 


### PR DESCRIPTION
Okay, take a look here @mariaparazorose. I think this version of the `combine_cession_ids` function handles the possible types encountered in the `all_cession_numbers` column correctly. I think we weren't accounting for instances of `np.number`-type values (and possibly also `None`-type outputs from the initial chunk of the function) previously.